### PR TITLE
Re-add hpaio on /etc/sane.d/dll.d

### DIFF
--- a/org.kde.skanpage.json
+++ b/org.kde.skanpage.json
@@ -192,7 +192,8 @@
                 }
             ],
             "post-install": [
-                "[ -f \"${FLATPAK_DEST}/etc/hp/hplip.conf\" ] || install -p -D \"hplip.conf\" -t \"${FLATPAK_DEST}/etc/hp/\";"
+                "[ -f \"${FLATPAK_DEST}/etc/hp/hplip.conf\" ] || install -p -D \"hplip.conf\" -t \"${FLATPAK_DEST}/etc/hp/\";",
+                "echo 'hpaio' > hpaio && install -p -D hpaio -t \"${FLATPAK_DEST}/etc/sane.d/dll.d/\";"
             ],
             "cleanup": [
                 "/lib/cups",


### PR DESCRIPTION
On my previous pull request I removed this line because I thought it wasn't needed, but it actually is. I noticed I still had native skanpage installed so I must have mistakenly tested with that instead.